### PR TITLE
Add more accurate mobile menu layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # QRWorldMenu
+
+Este repositorio contiene un ejemplo simplificado del menú móvil de Rock&Feller's. Incluye un `index.html` que replica la estructura principal y usa los estilos originales del sitio.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Rock&amp;Feller's Menu</title>
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/reset.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/plugins.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/style.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/dark-style.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/color.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/animate.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/custom.css?v=5">
+    <link rel="stylesheet" href="https://rockandfellers.com.ar/front/css/qr_menu.css?v=5">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="mobile-header">
+        <div class="logo-container row">
+            <div class="col-1"></div>
+            <div class="col-1 d-flex flex-column justify-content-center">
+                <a class="back" href="https://rockandfellers.com.ar/cartas-qr/rock-feller-s-savoy">
+                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                </a>
+            </div>
+            <div class="col-8">
+                <img class="logo" src="https://rockandfellers.com.ar/_business/logo_rf_dorado.png" alt="Logo de Rock & Feller's">
+            </div>
+        </div>
+        <div class="header-background-container">
+            <img class="header-background" src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-types/tTxpbCVxQTsqjXepsz1IpYZ3qcVLFnsbFOkeDxwI.png" alt="">
+            <div class="blurred"></div>
+        </div>
+    </header>
+    <main class="menu container">
+        <div class="menu-type-selector-container">
+            <select name="menu-selector" class="menu-type-selector" id="menu-selector">
+                <option selected value="https://rockandfellers.com.ar/cartas-qr/rock-feller-s-savoy/restaurante">Restaurante</option>
+                <option value="https://rockandfellers.com.ar/cartas-qr/rock-feller-s-savoy/cafeteria">Cafetería</option>
+                <option value="https://rockandfellers.com.ar/cartas-qr/rock-feller-s-savoy/vinos-y-espumantes">Vinos y Espumantes</option>
+                <option value="https://rockandfellers.com.ar/cartas-qr/rock-feller-s-savoy/cocktails">Cocktails</option>
+            </select>
+            <label for="menu-selector"><i class="fa fa-chevron-down" aria-hidden="true"></i></label>
+        </div>
+
+        <section class="categories-tags-container">
+            <h4>Categorías &amp; tags</h4>
+            <div class="categories-container owl-carousel owl-theme">
+                <div class="category-item item" data-category="31"><a href="#">ENTRADAS</a></div>
+                <div class="category-item item" data-category="33"><a href="#">ENSALADAS</a></div>
+                <div class="category-item item" data-category="32"><a href="#">PASTAS</a></div>
+                <div class="category-item item" data-category="7"><a href="#">CARNES &amp; PESCADOS</a></div>
+                <div class="category-item item" data-category="6"><a href="#">WOKS &amp; VEGGIE</a></div>
+                <div class="category-item item" data-category="35"><a href="#">TEX-MEX</a></div>
+                <div class="category-item item" data-category="36"><a href="#">SÁNDWICHES</a></div>
+                <div class="category-item item" data-category="19"><a href="#">MENÚ KIDS</a></div>
+                <div class="category-item item" data-category="48"><a href="#">SIN - TACC</a></div>
+                <div class="category-item item" data-category="37"><a href="#">POSTRES &amp; HELADOS</a></div>
+                <div class="category-item item" data-category="14"><a href="#">TORTAS &amp; CHEESECAKES</a></div>
+                <div class="category-item item" data-category="56"><a href="#">CAFETERIA CLÁSICA</a></div>
+                <div class="category-item item" data-category="21"><a href="#">GASEOSAS</a></div>
+                <div class="category-item item" data-category="39"><a href="#">AGUAS</a></div>
+                <div class="category-item item" data-category="40"><a href="#">JUGOS - LICUADOS</a></div>
+                <div class="category-item item" data-category="41"><a href="#">LIMONADAS</a></div>
+                <div class="category-item item" data-category="42"><a href="#">ENERGIZANTE</a></div>
+                <div class="category-item item" data-category="75"><a href="#">CHOPP &amp; BEERS</a></div>
+            </div>
+            <div class="tags-container owl-carousel owl-theme">
+                <div class="tag-item item d-flex align-items-center"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-tags/FtoqGOvaiA1XtzmRNz6AouCIf6Ss1adpuww4jO9B.png" alt="Tag VEGETARIANO"><span>VEGETARIANO</span></div>
+                <div class="tag-item item d-flex align-items-center"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-tags/XREfDzu7dRNCaSIh6LeYczqNmrCfKkRY5HFWL9yl.png" alt="Tag NEW"><span>NEW</span></div>
+                <div class="tag-item item d-flex align-items-center"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-tags/BD4wzu5SlOeJdnCH8Y0CWor4M1FtgPmU8RRVFnRc.png" alt="Tag VEGANO"><span>VEGANO</span></div>
+                <div class="tag-item item d-flex align-items-center"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/menu-tags/cOHjoJpbwWrhjTRVhlo9JlOfRNLURFJbzcPxsksc.svg" alt="Tag MENÚ KIDS"><span>MENÚ KIDS</span></div>
+                <div class="tag-item item d-flex align-items-center"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-tags/YFCFT1qm1B5HHAg7jsVJuABCK1sc7vFDjHUcGY8f.png" alt="Tag CELIACOS"><span>CELIACOS</span></div>
+                <div class="tag-item item d-flex align-items-center"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-tags/1M8DSpS0KoJ8VJFYhoikARMa80QxAYqCaku6ryBc.png" alt="Tag HH"><span>HH (PRECIO PROMOCIONAL)</span></div>
+            </div>
+        </section>
+
+        <section class="horizontal-menu">
+            <h2 class="menu-title">Sugerencia del Chef</h2>
+            <article class="row">
+                <div class="description-container col-7">
+                    <span class="product-title">.BURGER FEST.</span>
+                    <span class="product-description">Feller's Smash Burger + Stella Artois 330cc</span>
+                    <span class="product-price">$21000.00</span>
+                    <span class="more-info">+info</span>
+                </div>
+                <div class="image-container col-5">
+                    <img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/mQBSnqPa4jBG2ANchtWPb0capV4hFu1KZ35PWjnE.jpg" alt="Menu">
+                </div>
+            </article>
+            <article class="row">
+                <div class="description-container col-7">
+                    <span class="product-title">BURGER FEST</span>
+                    <span class="product-description">R&amp;F Mushroom Burger + Stella Artois 330 cc.</span>
+                    <span class="product-price">$21000.00</span>
+                    <span class="more-info">+info</span>
+                </div>
+                <div class="image-container col-5">
+                    <img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/mW82yJelNXC63sZNF6PUp4J8SOAeUvUULgrXqv25.jpg" alt="Menu">
+                </div>
+            </article>
+            <article class="row">
+                <div class="description-container col-7">
+                    <span class="product-title">.BURGER FEST..</span>
+                    <span class="product-description">Blue Cheese Bomb + Stella Artois 330cc.</span>
+                    <span class="product-price">$21000.00</span>
+                    <span class="more-info">+info</span>
+                </div>
+                <div class="image-container col-5">
+                    <img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/rN1t34Z4kclORWSAx9jgfwCEIszEEtSYVdlTxh05.jpg" alt="Menu">
+                </div>
+            </article>
+        </section>
+        <section class="horizontal-menu">
+            <h2 class="menu-title">- ENTRADAS -</h2>
+            <article class="row">
+                <div class="description-container col-7">
+                    <span class="product-title">Espinacas R&amp;F</span>
+                    <span class="product-description">Crema de espinaca</span>
+                    <span class="product-price">$14900.00</span>
+                    <span class="product-tag"><img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/menu-tags/FtoqGOvaiA1XtzmRNz6AouCIf6Ss1adpuww4jO9B.png" alt="Tag VEGETARIANO"></span>
+                    <span class="more-info">+info</span>
+                </div>
+                <div class="image-container col-5">
+                    <img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/products/460ee4a8cdaf08baeeeb738ae194b864.jpeg" alt="Menu">
+                </div>
+            </article>
+            <article class="row">
+                <div class="description-container col-7">
+                    <span class="product-title">Papas R&amp;F</span>
+                    <span class="product-description">Papas rústicas</span>
+                    <span class="product-price">$11900.00</span>
+                    <span class="more-info">+info</span>
+                </div>
+                <div class="image-container col-5">
+                    <img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/products/PAPAS_RF.jpeg" alt="Menu">
+                </div>
+            </article>
+            <article class="row">
+                <div class="description-container col-7">
+                    <span class="product-title">French Fries</span>
+                    <span class="product-description">Nuestras deliciosas papas bastón.</span>
+                    <span class="product-price">$8500.00</span>
+                    <span class="more-info">+info</span>
+                </div>
+                <div class="image-container col-5">
+                    <img src="https://web-app-prod-01.nyc3.cdn.digitaloceanspaces.com/ryf_media/1dtqNBtXx7eIeZpundsmBpBEjECkTKQdHtYLTzID.jpg" alt="Menu">
+                </div>
+            </article>
+        </section>
+        <!-- Secciones adicionales irían aquí -->
+    </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+body{
+    font-family: Arial, sans-serif;
+    margin:0;
+    padding:0;
+}
+.mobile-header{
+    background:#111;
+    color:#fff;
+    padding:10px;
+    position:relative;
+}
+.mobile-header .logo-container{
+    display:flex;
+    align-items:center;
+}
+.mobile-header .back{
+    margin-right:10px;
+}
+.menu.container{
+    padding:10px;
+}
+.menu-type-selector-container{
+    margin-bottom:10px;
+}
+.categories-container, .tags-container{
+    display:flex;
+    flex-wrap:wrap;
+    gap:5px;
+    margin-bottom:10px;
+}
+.category-item, .tag-item{
+    background:#eee;
+    padding:5px 10px;
+    border-radius:4px;
+    font-size:0.9em;
+}
+.horizontal-menu .row{
+    display:flex;
+    margin-bottom:10px;
+}
+.description-container{
+    flex:1;
+}
+.image-container img{
+    width:100px;
+    height:auto;
+}
+.product-title{
+    font-weight:bold;
+}
+.product-price{
+    color:#c00;
+}


### PR DESCRIPTION
## Summary
- link to the original site's CSS files for accurate styles
- replicate header layout and menu selector options
- populate categories, tags, and menu items with examples from the live menu
- clean up README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841f1dd23d4832dbf2410f62ebb0627