### PR TITLE
Enable closing modal on overlay click

### DIFF
--- a/index.html
+++ b/index.html
@@ -614,10 +614,20 @@
           modal.classList.add("flex");
         });
 
-        document.getElementById("modal-close-button").onclick = () => {
+        function closeModal() {
           modal.classList.add("hidden");
           modal.classList.remove("flex");
-        };
+        }
+
+        document
+          .getElementById("modal-close-button")
+          .addEventListener("click", closeModal);
+
+        modal.addEventListener("click", (e) => {
+          if (e.target === modal) {
+            closeModal();
+          }
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- update modal script so clicking outside closes it

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68439c89ea48832d876c2dc4914bc583